### PR TITLE
Fix install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 ## Install
 
 ```bash
-npm add gatsby-query-params
+# Using npm
+npm install gatsby-query-params
+
+# Using Yarn
+yarn add gatsby-query-params
 ```
 
 ## Function Signature


### PR DESCRIPTION
`npm add` doesn't exist, so I've added instructions for both npm and yarn. Hope this helps!